### PR TITLE
Add deployed backend URL in README

### DIFF
--- a/Back-End/README.md
+++ b/Back-End/README.md
@@ -101,7 +101,7 @@ For queries or contributions, contact **[jagerjackson001@gmail.com]** or open an
 
 The backend server is deployed and live at the following URL:
 
-👉 [https://s70-dron-aadhar-system.onrender.com](https://s70-dron-aadhar-system.onrender.com)
+👉 [https://s70-dron-aadhar-system.onrender.com]   (https://s70-dron-aadhar-system.onrender.com)
 
 Use this base URL to make API requests, such as:
 
@@ -118,7 +118,7 @@ Use this base URL to make API requests, such as:
 
 The frontend is live and deployed at the following link:
 
-👉 [https://relaxed-pika-2c32f9.netlify.app](https://relaxed-pika-2c32f9.netlify.app)
+👉 [https://relaxed-pika-2c32f9.netlify.app]    (https://relaxed-pika-2c32f9.netlify.app)
 git checkout -b feat/frontend-deployment
 
 This is the user-facing React + Vite interface for securely accessing Aadhar-linked health records .


### PR DESCRIPTION
### **User description**
### 🛠️ Updated README.md with Deployed Backend URL

- Added the live backend server URL hosted on **Render.com**.
- The backend is used for handling API requests such as user auth, record creation, update, delete, and file upload.
- Included base endpoints like:
  - `GET /api/records`
  - `POST /api/records`
  - `PUT /api/records/:id`
  - `DELETE /api/records/:id`
- This will help reviewers/testers easily connect with the live backend.

🔗 **Live Backend URL**: [https://s70-dron-aadhar-system.onrender.com](https://s70-dron-aadhar-system.onrender.com)

> Note: Root route (`/`) shows `Cannot GET /` because it's an API-only backend.


___

### **PR Type**
Documentation


___

### **Description**
- Fix markdown link formatting for deployed URLs

- Correct syntax for backend and frontend deployment links


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Fix markdown link formatting for deployment URLs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Back-End/README.md

<li>Fixed markdown link syntax for backend deployment URL<br> <li> Fixed markdown link syntax for frontend deployment URL<br> <li> Corrected formatting from inline links to reference-style links


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/s70_Dron_Aadhar_System/pull/15/files#diff-a9cc257e0bbcbf4c8b38dcf87d368ec8f9e9367e987e25c0d7eb235966bcd9df">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>